### PR TITLE
RC 250

### DIFF
--- a/changelogs/v2_50.md
+++ b/changelogs/v2_50.md
@@ -1,0 +1,17 @@
+**Deidril's Pathfinder 2 PDF Import v2.50**
+For foundry V11 AND pf2e system 5.7.4+
+
+*Update*
+Fixed the missing map for Ennmity Cycle
+Fixed token generations for Crown of the Kobold King, which was still using the old colored circles instead of the token rings.
+Fixed the summary screen for a few imports
+
+**Deidril's Pathfinder 2 PDF Import v2.50**
+Pour foundry V11 ET pf2e system 5.7.4+
+
+*Mise à jour*
+Correction de la scène manquante dans Ennmity cycle
+Correction de la génération des tokens pour Crown of the Kobold Kin, qui utilisait toujours les vieux cercles colorés en lieu des tokens rings.
+Correction de la fenêtre de résumé de l'import pour quelques imports
+
+

--- a/module.json
+++ b/module.json
@@ -12,7 +12,7 @@
       "flags": {}
     }
   ],
-  "version": "2.49",
+  "version": "2.50",
   "compatibility": {
     "minimum": "11",
     "verified": "11",
@@ -30,7 +30,7 @@
   "relationships": {
     "systems":
     [
-      { "id": "pf2e", "type": "system", "compatibility": { "minimum": "5.7.2", "verified": "5.7.4" } }
+      { "id": "pf2e", "type": "system", "compatibility": { "minimum": "5.7.2", "verified": "5.8.2" } }
     ]
   },
   "scripts": [
@@ -53,5 +53,5 @@
   "url": "https://github.com/deidril/pf2-pdf-en-import",
   "issues": "https://github.com/deidril/pf2-pdf-en-import/issues",
   "manifest": "https://github.com/deidril/pf2-pdf-en-import/releases/latest/download/module.json",
-  "download": "https://github.com/deidril/pf2-pdf-en-import/releases/download/2.49/pf2-pdf-en-import-2.49.zip"
+  "download": "https://github.com/deidril/pf2-pdf-en-import/releases/download/2.50/pf2-pdf-en-import-2.50.zip"
 }


### PR DESCRIPTION
**Deidril's Pathfinder 2 PDF Import v2.50**
For foundry V11 AND pf2e system 5.7.4+

*Update*
Fixed the missing map for Ennmity Cycle
Fixed token generations for Crown of the Kobold King, which was still using the old colored circles instead of the token rings.
Fixed the summary screen for a few imports
