### PR TITLE
V11/r251

### DIFF
--- a/changelogs/v2_51.md
+++ b/changelogs/v2_51.md
@@ -1,0 +1,40 @@
+**Deidril's Pathfinder 2 PDF Import v2.51**
+For foundry V11 AND pf2e system 5.9.3+
+
+*Remaster version*
+The remaster version has little impact on the import module. 
+There is some broken links to compendiums entries in the loot section, when an item has been removed or renamed.
+But imports doesn't seem to be broken.
+I think it will be very different when the new bestiary arrives in january. /cringe
+
+*Updating*
+Since a few release, I'm looping over old imports and fix remaining issues or update imports with little things.
+Now I'm also fixing remaster's renamed items. 
+They will be listed this way when renamed : [Link to the new items] *(old name)*
+Example : [Obsidian googles] *(Googles of Night)*
+
+*NPCs*
+There are npcs with art but are described only with a simple sentence ( Example : Gerald **(N male human witch)** )
+I now import them, using the 'Commoner' npc template to build this npc.
+Most of them are not to be used except in pure roleplay scenes, so skills and levels doesn't matter and it would
+be a too much big work of creating them correctly.
+They are put in the ScenarioName/NPCs folder
+
+*PFS3E13* : Fixed orientation of maps, added npcs, fixed links of renamed items
+
+*PFS3E14* : Added npcs
+
+*PFS3E15* : Added npcs
+
+
+
+
+**Deidril's Pathfinder 2 PDF Import v2.51**
+Pour foundry V11 ET pf2e system 5.9.3+
+
+*Mise à jour*
+Correction de la scène manquante dans Ennmity cycle
+Correction de la génération des tokens pour Crown of the Kobold Kin, qui utilisait toujours les vieux cercles colorés en lieu des tokens rings.
+Correction de la fenêtre de résumé de l'import pour quelques imports
+
+

--- a/changelogs/v2_51.md
+++ b/changelogs/v2_51.md
@@ -12,6 +12,7 @@ Since a few release, I'm looping over old imports and fix remaining issues or up
 Now I'm also fixing remaster's renamed items. 
 They will be listed this way when renamed : [Link to the new items] *(old name)*
 Example : [Obsidian googles] *(Googles of Night)*
+I'll be looping over all imports, but if you find a broken link, please tell me and I'll focus on that pdf.
 
 *NPCs*
 There are npcs with art but are described only with a simple sentence ( Example : Gerald **(N male human witch)** )
@@ -21,20 +22,34 @@ be a too much big work of creating them correctly.
 They are put in the ScenarioName/NPCs folder
 
 *PFS3E13* : Fixed orientation of maps, added npcs, fixed links of renamed items
-
 *PFS3E14* : Added npcs
-
-*PFS3E15* : Added npcs
-
-
-
 
 **Deidril's Pathfinder 2 PDF Import v2.51**
 Pour foundry V11 ET pf2e system 5.9.3+
 
+*Version Remaster*
+La version remaster n'a finalement que peu d'impact sur le module d'import.
+Il y a quelques liens buggués vers des équipements dans les compendiums, dans les section 'inventaire' des pages des journaux, 
+lorsqu'un objet a été supprimé ou renommé.
+Mais les imports n'en sont pas impactés ou bloqués pour autant.
+Je pense que les choses seront très différentes lorsque le nouveau bestiaire arrivera. /frayeur
+Je vais normalement passer sur tous les imports, mais si vous trouvez un lien vers un objet qui ne fonctionne plus en remaster,
+vous pouvez me le signaler, et je ferai un focus dessus.
+
 *Mise à jour*
-Correction de la scène manquante dans Ennmity cycle
-Correction de la génération des tokens pour Crown of the Kobold Kin, qui utilisait toujours les vieux cercles colorés en lieu des tokens rings.
-Correction de la fenêtre de résumé de l'import pour quelques imports
+Depuis quelques versions, j'itère sur les vieux imports pour réparer les erreurs laissées en suspend, ou bien les mettre 
+à jour avec des fonctionnalités plus récentes.
+Désormais, je répare aussi les liens des objets renommés.
+Ils seront listés dans les journaux selon ce format : [Lien vers le nouvel objet] *(ancien nom)*
+Exemple :  [Obsidian googles] *(Googles of Night)*
 
 
+*NPCs*
+Il y a souvent des npcs avec une image, mais décrits par une simple phrase. (Exemple : Gérals **(N male humain sorceleur)**)
+Je vais maintenant les importer, en utilisant l'archetype de npc 'Commoner'.
+La plupart d'entre eux n'existent que pour des scènes de pure roleplay, et donc leur niveau ou leur compétences ne sont
+âs important, et cela serait trop de travail de les créer correctement.
+Ils sont rangés dans le dossier Scenario/NPCs
+
+*PFS3E13* : Correction des scènes mal orientées, ajouts des npcs, correction des objets renommés
+*PFS3E14* : Ajout des npcs

--- a/module.json
+++ b/module.json
@@ -12,7 +12,7 @@
       "flags": {}
     }
   ],
-  "version": "2.50",
+  "version": "2.51",
   "compatibility": {
     "minimum": "11",
     "verified": "11",
@@ -30,7 +30,7 @@
   "relationships": {
     "systems":
     [
-      { "id": "pf2e", "type": "system", "compatibility": { "minimum": "5.7.2", "verified": "5.8.2" } }
+      { "id": "pf2e", "type": "system", "compatibility": { "minimum": "5.9.2", "verified": "5.9.3" } }
     ]
   },
   "scripts": [
@@ -53,5 +53,5 @@
   "url": "https://github.com/deidril/pf2-pdf-en-import",
   "issues": "https://github.com/deidril/pf2-pdf-en-import/issues",
   "manifest": "https://github.com/deidril/pf2-pdf-en-import/releases/latest/download/module.json",
-  "download": "https://github.com/deidril/pf2-pdf-en-import/releases/download/2.50/pf2-pdf-en-import-2.50.zip"
+  "download": "https://github.com/deidril/pf2-pdf-en-import/releases/download/2.51/pf2-pdf-en-import-2.51.zip"
 }

--- a/module.json
+++ b/module.json
@@ -30,7 +30,7 @@
   "relationships": {
     "systems":
     [
-      { "id": "pf2e", "type": "system", "compatibility": { "minimum": "5.9.2", "verified": "5.9.3" } }
+      { "id": "pf2e", "type": "system", "compatibility": { "minimum": "5.9.2", "verified": "5.9.4" } }
     ]
   },
   "scripts": [


### PR DESCRIPTION
**Deidril's Pathfinder 2 PDF Import v2.51**
For foundry V11 AND pf2e system 5.9.3+

*Remaster version*
The remaster version has little impact on the import module. 
There is some broken links to compendiums entries in the loot section, when an item has been removed or renamed.
But imports doesn't seem to be broken.
I think it will be very different when the new bestiary arrives in january. /cringe

*Updating*
Since a few release, I'm looping over old imports and fix remaining issues or update imports with little things.
Now I'm also fixing remaster's renamed items. 
They will be listed this way when renamed : [Link to the new items] *(old name)*
Example : [Obsidian googles] *(Googles of Night)*
I'll be looping over all imports, but if you find a broken link, please tell me and I'll focus on that pdf.

*NPCs*
There are npcs with art but are described only with a simple sentence ( Example : Gerald **(N male human witch)** )
I now import them, using the 'Commoner' npc template to build this npc.
Most of them are not to be used except in pure roleplay scenes, so skills and levels doesn't matter and it would
be a too much big work of creating them correctly.
They are put in the ScenarioName/NPCs folder

*PFS3E13* : Fixed orientation of maps, added npcs, fixed links of renamed items
*PFS3E14* : Added npcs