### PR TITLE
RC 2.53

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ images in ~/datas/images are generated through Midjourney by Deidril. Their use 
 ## Pathfinder Society Quests
 - #14 : The Swordlord’s Challenge
 - #15 : In the Footsteps of Horror
+- #16 : The Winter Queen's Dollhouse
 
 ## Pathfinder Society Season 3
 - Episode 12 : Fury's Toll

--- a/changelogs/v2_53.md
+++ b/changelogs/v2_53.md
@@ -1,0 +1,16 @@
+**Deidril's Pathfinder 2 PDF Import v2.53**
+For foundry V11 AND pf2e system 5.11+
+
+*Updates* : Added missing npcs for PFS4E17, PFS4E01, PFS4E02 and PFS4E03
+
+*New imports* : The module will now import Quest #16's pdf : **The Winter Queen's Dollhouse**, but
+since the actors aren't yet in the system compendiums, you'll get journals and scenes but no actors fow now.
+
+**Deidril's Pathfinder 2 PDF Import v2.53**
+Pour foundry V11 ET pf2e system 5.11+
+
+*Updates* : Ajouts des npcs manquants pour les scénarios PFS4E17, PFS4E01, PFS4E02 et PFS4E03
+
+*Nouveaux imports* : Le module importe désormais le PDF de la quête #16 : **The Winter Queen's Dollhouse**,
+mais comme les acteurs ne sont pas encore dans les compendiums, le module installera les journaux et les scenes, 
+mais pas (encore) les créatures.

--- a/module.json
+++ b/module.json
@@ -12,7 +12,7 @@
       "flags": {}
     }
   ],
-  "version": "2.52",
+  "version": "2.53",
   "compatibility": {
     "minimum": "11",
     "verified": "11",
@@ -30,7 +30,7 @@
   "relationships": {
     "systems":
     [
-      { "id": "pf2e", "type": "system", "compatibility": { "minimum": "5.9.2", "verified": "5.9.4" } }
+      { "id": "pf2e", "type": "system", "compatibility": { "minimum": "5.11", "verified": "5.11.5" } }
     ]
   },
   "scripts": [
@@ -53,5 +53,5 @@
   "url": "https://github.com/deidril/pf2-pdf-en-import",
   "issues": "https://github.com/deidril/pf2-pdf-en-import/issues",
   "manifest": "https://github.com/deidril/pf2-pdf-en-import/releases/latest/download/module.json",
-  "download": "https://github.com/deidril/pf2-pdf-en-import/releases/download/2.52/pf2-pdf-en-import-2.52.zip"
+  "download": "https://github.com/deidril/pf2-pdf-en-import/releases/download/2.53/pf2-pdf-en-import-2.53.zip"
 }

--- a/templates/exported/pdfList.hbs
+++ b/templates/exported/pdfList.hbs
@@ -30,6 +30,7 @@ Anonymized PDFs will not be imported</p>
 <ul>
     <li>#14 : The Swordlord’s Challenge</li>
     <li>#15 : In the Footsteps of Horror</li>
+    <li>#16 : The Winter Queen's Dollhouse</li>
 </ul>
 <p><b>Pathfinder Society Season 3</b></p>
 <ul>


### PR DESCRIPTION
For foundry V11 AND pf2e system 5.11+

*Updates* : Added missing npcs for PFS4E17, PFS4E01, PFS4E02 and PFS4E03

*New imports* : The module will now import Quest #16's pdf : **The Winter Queen's Dollhouse**, but
since the actors aren't yet in the system compendiums, you'll get journals and scenes but no actors fow now.